### PR TITLE
Set tx_isolation to read-committed

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -20,3 +20,4 @@ thread_cache_size = 8
 thread_stack = 256K
 tmp_table_size = 32M
 host_cache_size=0
+tx_isolation="READ-COMMITTED"

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -20,4 +20,4 @@ thread_cache_size = 8
 thread_stack = 256K
 tmp_table_size = 32M
 host_cache_size=0
-tx_isolation="READ-COMMITTED"
+transaction-isolation="READ-COMMITTED"


### PR DESCRIPTION
Set `tx_isolation` to `READ-COMMITTED`.

More information:
https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level