### PR TITLE
Disable bin logging

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,4 +1,5 @@
 [mysqld]
+disable_log_bin
 port=3306
 bind-address = 0.0.0.0
 sql_mode=STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION,NO_AUTO_VALUE_ON_ZERO
@@ -11,7 +12,6 @@ innodb_log_buffer_size = 8M
 innodb_redo_log_capacity = 134217728
 key_buffer_size = 16M
 max_allowed_packet = 256M
-max_binlog_size = 100M
 max_connections = 151
 max_heap_table_size = 32M
 open_files_limit = 2048


### PR DESCRIPTION
**Overview**

We have seen our preview environments become evicted over time because the bin logs continue to grow.

We have also seen this files included in our database imaging pipelines.

We don't need bin logs for database images.

**Solution**

Turn it off

**Comparison**

We did some testing with a 100M database import.

The size of /var/lib/mysql

```
Before = 900M
After = 600M
```

It will also not continue to grow after the database image is running.