### PR TITLE
chore: updates image tags from latest to stable and edge to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ workflows:
             branches:
               ignore: [ main, releases ]
 
-  build_latest:
+  build_edge:
     jobs:
       - build:
-          stream: latest
+          stream: edge
           context: docker-publishing
           matrix:
             parameters:
@@ -40,7 +40,7 @@ workflows:
             branches:
               only: [ main ]
       - manifest:
-          stream: latest
+          stream: edge
           context: docker-publishing
           requires: [ build ]
           filters:
@@ -66,7 +66,7 @@ workflows:
             branches:
               only: [ releases ]
 
-  nightly_latest:
+  build_latest:
     jobs:
       - build:
           stream: latest
@@ -76,9 +76,28 @@ workflows:
               executor: *platforms
           filters:
             branches:
-              only: [ main ]
+              only: [ releases ]
       - manifest:
           stream: latest
+          context: docker-publishing
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_edge:
+    jobs:
+      - build:
+          stream: edge
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+          filters:
+            branches:
+              only: [ main ]
+      - manifest:
+          stream: edge
           context: docker-publishing
           requires: [ build ]
           filters:
@@ -105,6 +124,32 @@ workflows:
               only: [ releases ]
       - manifest:
           stream: stable
+          context: docker-publishing
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+    triggers:
+      - schedule:
+          # Scheduled build for 2am AEST nightly.
+          cron: "0 15 * * *"
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+          filters:
+            branches:
+              only: [ releases ]
+      - manifest:
+          stream: latest
           context: docker-publishing
           requires: [ build ]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,25 +28,6 @@ workflows:
             branches:
               ignore: [ main, releases ]
 
-  build_edge:
-    jobs:
-      - build:
-          stream: edge
-          context: docker-publishing
-          matrix:
-            parameters:
-              executor: *platforms
-          filters:
-            branches:
-              only: [ main ]
-      - manifest:
-          stream: edge
-          context: docker-publishing
-          requires: [ build ]
-          filters:
-            branches:
-              only: [ main ]
-
   build_latest:
     jobs:
       - build:
@@ -57,19 +38,38 @@ workflows:
               executor: *platforms
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
       - manifest:
           stream: latest
           context: docker-publishing
           requires: [ build ]
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
 
-  nightly_edge:
+  build_stable:
     jobs:
       - build:
-          stream: edge
+          stream: stable
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+          filters:
+            branches:
+              only: [ releases ]
+      - manifest:
+          stream: stable
+          context: docker-publishing
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
           context: docker-publishing
           matrix:
             parameters:
@@ -78,7 +78,7 @@ workflows:
             branches:
               only: [ main ]
       - manifest:
-          stream: edge
+          stream: latest
           context: docker-publishing
           requires: [ build ]
           filters:
@@ -92,10 +92,10 @@ workflows:
             branches:
               only: [ main ]
 
-  nightly_latest:
+  nightly_stable:
     jobs:
       - build:
-          stream: latest
+          stream: stable
           context: docker-publishing
           matrix:
             parameters:
@@ -104,7 +104,7 @@ workflows:
             branches:
               only: [ releases ]
       - manifest:
-          stream: latest
+          stream: stable
           context: docker-publishing
           requires: [ build ]
           filters:


### PR DESCRIPTION
## Overview

Update Image tags from `edge` to `latest` and update `latest` to `stable`

## Implementation

I've updated the image tags and even stage names to reflect the change

## How to Test

Running the build pipeline will build the tags as intended

## What is the rollout plan?

We need to update skpr to use the new image tags and for those projects not on skpr update their pipelines. 

## Does this change need a blog post?

No

## Link to Tickets

* https://previousnext.atlassian.net/browse/SKPR-958 